### PR TITLE
feat(upgrade): upgrade to `mojo 0.2.1 (64d14e85)`

### DIFF
--- a/libc.mojo
+++ b/libc.mojo
@@ -127,6 +127,56 @@ fn external_call6[
         )
 
 
+@always_inline("nodebug")
+fn external_call7[
+    callee: StringLiteral,
+    type: AnyType,
+    T0: AnyType,
+    T1: AnyType,
+    T2: AnyType,
+    T3: AnyType,
+    T4: AnyType,
+    T5: AnyType,
+    T6: AnyType,
+](arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) -> type:
+    """Call an external function.
+
+    Parameters:
+      callee: The name of the external function.
+      type: The return type.
+      T0: The first argument type.
+      T1: The second argument type.
+      T2: The third argument type.
+      T3: The fourth argument type.
+      T4: The fifth argument type.
+      T5: The sixth argument type.
+      T6: The seventh argument type.
+
+    Args:
+      arg0: The first argument.
+      arg1: The second argument.
+      arg2: The third argument.
+      arg3: The fourth argument.
+      arg4: The fifth argument.
+      arg5: The sixth argument.
+      arg6: The seventh argument.
+
+    Returns:
+      The external call result.
+    """
+
+    @parameter
+    if _mlirtype_is_eq[type, NoneType]():
+        __mlir_op.`pop.external_call`[func : callee.value, _type:None](
+            arg0, arg1, arg2, arg3, arg4, arg5, arg6
+        )
+        return rebind[type](None)
+    else:
+        return __mlir_op.`pop.external_call`[func : callee.value, _type:type](
+            arg0, arg1, arg2, arg3, arg4, arg5, arg6
+        )
+
+
 # --- ( Network Related Constants )---------------------------------------------
 alias sa_family_t = c_ushort
 alias socklen_t = c_uint
@@ -1210,74 +1260,199 @@ fn fprintf[
     ](stream, format, args)
 
 
-fn printf[*T: AnyType](format: Pointer[c_char], *args: *T) -> c_int:
-    """Libc POSIX `printf` function.
-
-    Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
-    Fn signature: int printf(const char *restrict format, ...)
-
-    Args:
-        format: A format string.
-        args: Arguments for the format string.
-    Returns: A File Descriptor or -1 in case of failure
-    """
-    return external_call[
-        "printf",
-        c_int,  # FnName, RetType
-        Pointer[c_char],  # Args
-    ](format, args)
+# printf's family function(s) this is used to implement the rest of the printf's family
+fn _printf[callee: StringLiteral](format: Pointer[c_char]) -> c_int:
+    return external_call[callee, c_int, Pointer[c_char]](format)
 
 
-fn printf[*T: AnyType](format: Pointer[c_char]) -> c_int:
-    """Libc POSIX `printf` function.
-
-    Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
-    Fn signature: int printf(const char *restrict format, ...)
-
-    Args:
-        format: A format string.
-    Returns: A File Descriptor or -1 in case of failure
-    """
-    return external_call[
-        "printf",
-        c_int,  # FnName, RetType
-        Pointer[c_char],  # Args
-    ](format)
+fn _printf[
+    callee: StringLiteral, T0: AnyType
+](format: Pointer[c_char], arg0: T0) -> c_int:
+    return external_call[callee, c_int, Pointer[c_char], T0](format, arg0)
 
 
-fn printf[*T: AnyType](format: StringLiteral, *args: *T) -> c_int:
-    """Libc POSIX `printf` function.
-
-    Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
-    Fn signature: int printf(const char *restrict format, ...)
-
-    Args:
-        format: A format string.
-        args: Arguments for the format string.
-    Returns: A File Descriptor or -1 in case of failure
-    """
-    return external_call[
-        "printf",
-        c_int,  # FnName, RetType
-        Pointer[c_char],  # Args
-    ](to_char_ptr(format), args)
+fn _printf[
+    callee: StringLiteral, T0: AnyType, T1: AnyType
+](format: Pointer[c_char], arg0: T0, arg1: T1) -> c_int:
+    return external_call[callee, c_int, Pointer[c_char], T0, T1](format, arg0, arg1)
 
 
-fn printf[*T: AnyType](format: StringLiteral) -> c_int:
-    """Libc POSIX `printf` function.
+fn _printf[
+    callee: StringLiteral, T0: AnyType, T1: AnyType, T2: AnyType
+](format: Pointer[c_char], arg0: T0, arg1: T1, arg2: T2) -> c_int:
+    return external_call[callee, c_int, Pointer[c_char], T0, T1, T2](
+        format, arg0, arg1, arg2
+    )
 
-    Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
-    Fn signature: int printf(const char *restrict format, ...)
 
-    Args:
-        format: A format string.
-    Returns: A File Descriptor or -1 in case of failure
-    """
-    return external_call[
-        "printf",
-        c_int,  # FnName, RetType
-        Pointer[c_char],  # Args
-    ](to_char_ptr(format))
+fn _printf[
+    callee: StringLiteral, T0: AnyType, T1: AnyType, T2: AnyType, T3: AnyType
+](format: Pointer[c_char], arg0: T0, arg1: T1, arg2: T2, arg3: T3) -> c_int:
+    return external_call[callee, c_int, Pointer[c_char], T0, T1, T2, T3](
+        format, arg0, arg1, arg2, arg3
+    )
+
+
+fn _printf[
+    callee: StringLiteral,
+    T0: AnyType,
+    T1: AnyType,
+    T2: AnyType,
+    T3: AnyType,
+    T4: AnyType,
+](format: Pointer[c_char], arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4) -> c_int:
+    return external_call6[callee, c_int, Pointer[c_char], T0, T1, T2, T3, T4](
+        format, arg0, arg1, arg2, arg3, arg4
+    )
+
+
+fn _printf[
+    callee: StringLiteral,
+    T0: AnyType,
+    T1: AnyType,
+    T2: AnyType,
+    T3: AnyType,
+    T4: AnyType,
+    T5: AnyType,
+](
+    format: Pointer[c_char], arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5
+) -> c_int:
+    return external_call7[callee, c_int, Pointer[c_char], T0, T1, T2, T3, T4, T5](
+        format, arg0, arg1, arg2, arg3, arg4, arg5
+    )
+
+
+fn _printf[callee: StringLiteral](format: String) -> c_int:
+    return _printf[callee](to_char_ptr(format))
+
+
+fn _printf[callee: StringLiteral, T0: AnyType](format: String, arg0: T0) -> c_int:
+    return _printf[callee, T0](to_char_ptr(format), arg0)
+
+
+fn _printf[
+    callee: StringLiteral, T0: AnyType, T1: AnyType
+](format: String, arg0: T0, arg1: T1) -> c_int:
+    return _printf[callee, T0, T1](to_char_ptr(format), arg0, arg1)
+
+
+fn _printf[
+    callee: StringLiteral, T0: AnyType, T1: AnyType, T2: AnyType
+](format: String, arg0: T0, arg1: T1, arg2: T2) -> c_int:
+    return _printf[callee, T0, T1, T2](to_char_ptr(format), arg0, arg1, arg2)
+
+
+fn _printf[
+    callee: StringLiteral, T0: AnyType, T1: AnyType, T2: AnyType, T3: AnyType
+](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3) -> c_int:
+    return _printf[callee, T0, T1, T2, T3](to_char_ptr(format), arg0, arg1, arg2, arg3)
+
+
+fn _printf[
+    callee: StringLiteral,
+    T0: AnyType,
+    T1: AnyType,
+    T2: AnyType,
+    T3: AnyType,
+    T4: AnyType,
+](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4) -> c_int:
+    return _printf[callee, T0, T1, T2, T3, T4](
+        to_char_ptr(format), arg0, arg1, arg2, arg3, arg4
+    )
+
+
+fn _printf[
+    callee: StringLiteral,
+    T0: AnyType,
+    T1: AnyType,
+    T2: AnyType,
+    T3: AnyType,
+    T4: AnyType,
+    T5: AnyType,
+](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) -> c_int:
+    return _printf[callee, T0, T1, T2, T3, T4, T5](
+        to_char_ptr(format), arg0, arg1, arg2, arg3, arg4, arg5
+    )
+
+
+fn printf(format: Pointer[c_char]) -> c_int:
+    return _printf["printf"](format)
+
+
+fn printf[T0: AnyType](format: Pointer[c_char], arg0: T0) -> c_int:
+    return _printf["printf", T0](format, arg0)
+
+
+fn printf[
+    T0: AnyType, T1: AnyType
+](format: Pointer[c_char], arg0: T0, arg1: T1) -> c_int:
+    return _printf["printf", T0, T1](format, arg0, arg1)
+
+
+fn printf[
+    T0: AnyType, T1: AnyType, T2: AnyType
+](format: Pointer[c_char], arg0: T0, arg1: T1, arg2: T2) -> c_int:
+    return _printf["printf", T0, T1, T2](format, arg0, arg1, arg2)
+
+
+fn printf[
+    T0: AnyType, T1: AnyType, T2: AnyType, T3: AnyType
+](format: Pointer[c_char], arg0: T0, arg1: T1, arg2: T2, arg3: T3) -> c_int:
+    return _printf["printf", T0, T1, T2, T3](format, arg0, arg1, arg2, arg3)
+
+
+fn printf[
+    T0: AnyType, T1: AnyType, T2: AnyType, T3: AnyType, T4: AnyType
+](format: Pointer[c_char], arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4) -> c_int:
+    return _printf["printf", T0, T1, T2, T3, T4](format, arg0, arg1, arg2, arg3, arg4)
+
+
+fn printf[
+    T0: AnyType, T1: AnyType, T2: AnyType, T3: AnyType, T4: AnyType, T5: AnyType
+](
+    format: Pointer[c_char], arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5
+) -> c_int:
+    return _printf["printf", T0, T1, T2, T3, T4, T5](
+        format, arg0, arg1, arg2, arg3, arg4, arg5
+    )
+
+
+fn printf(format: String) -> c_int:
+    return _printf["printf"](format)
+
+
+fn printf[T0: AnyType](format: String, arg0: T0) -> c_int:
+    return _printf["printf", T0](format, arg0)
+
+
+fn printf[T0: AnyType, T1: AnyType](format: String, arg0: T0, arg1: T1) -> c_int:
+    return _printf["printf", T0, T1](format, arg0, arg1)
+
+
+fn printf[
+    T0: AnyType, T1: AnyType, T2: AnyType
+](format: String, arg0: T0, arg1: T1, arg2: T2) -> c_int:
+    return _printf["printf", T0, T1, T2](format, arg0, arg1, arg2)
+
+
+fn printf[
+    T0: AnyType, T1: AnyType, T2: AnyType, T3: AnyType
+](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3) -> c_int:
+    return _printf["printf", T0, T1, T2, T3](format, arg0, arg1, arg2, arg3)
+
+
+fn printf[
+    T0: AnyType, T1: AnyType, T2: AnyType, T3: AnyType, T4: AnyType
+](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4) -> c_int:
+    return _printf["printf", T0, T1, T2, T3, T4](format, arg0, arg1, arg2, arg3, arg4)
+
+
+fn printf[
+    T0: AnyType, T1: AnyType, T2: AnyType, T3: AnyType, T4: AnyType, T5: AnyType
+](format: String, arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) -> c_int:
+    return _printf["printf", T0, T1, T2, T3, T4, T5](
+        format, arg0, arg1, arg2, arg3, arg4, arg5
+    )
 
 
 fn snprintf[
@@ -1732,8 +1907,8 @@ fn __test_getaddrinfo__():
     _ = external_call["printf", c_int, Pointer[c_char], Pointer[c_char]](
         to_char_ptr("gai_strerror: %s"), msg_ptr
     )
-    let msg = c_charptr_to_string(msg_ptr)
-    _ = printf("getaddrinfo satus: %d", msg)
+    # let msg = c_charptr_to_string(msg_ptr)
+    _ = printf("getaddrinfo satus: %d", msg_ptr)
     # getaddrinfo()
 
 

--- a/libc.mojo
+++ b/libc.mojo
@@ -1,37 +1,29 @@
-from DType import DType
-from Intrinsics import external_call
-from Memory import memset, memset_zero
-from Pointer import Pointer
-from SIMD import SIMD, UInt16
-from StaticTuple import StaticTuple as StaticArray
-from String import String, chr, ord
-from TargetInfo import sizeof
-from TypeUtilities import _mlirtype_is_eq, rebind
-from IO import _printf
-
+from sys.info import sizeof
+from sys.intrinsics import external_call, _mlirtype_is_eq
+from memory import memset, memset_zero
+from utils.static_tuple import StaticTuple
 
 # Types aliases
-alias c_void = UInt8 
+alias c_void = UInt8
 alias c_char = UInt8
 alias c_schar = Int8
 alias c_uchar = UInt8
 alias c_short = Int16
 alias c_ushort = UInt16
 alias c_int = Int32
-alias c_uint = UInt32 
+alias c_uint = UInt32
 alias c_long = Int64
 alias c_ulong = UInt64
 alias c_float = Float32
 alias c_double = Float64
 
-# Note: `Int` is known to be machine's width 
-alias c_size_t = Int;
-alias c_ssize_t = Int;
+# Note: `Int` is known to be machine's width
+alias c_size_t = Int
+alias c_ssize_t = Int
 
-alias ptrdiff_t = Int64;
-alias intptr_t = Int64;
-alias uintptr_t = UInt64;
-
+alias ptrdiff_t = Int64
+alias intptr_t = Int64
+alias uintptr_t = UInt64
 
 # --- ( error.h Constants )-----------------------------------------------------
 alias EPERM = 1
@@ -72,7 +64,7 @@ alias EWOULDBLOCK = EAGAIN
 
 
 fn to_char_ptr(s: String) -> Pointer[c_char]:
-    """only ASCII-based strings"""
+    """Only ASCII-based strings."""
     let ptr = Pointer[c_char]().alloc(len(s))
     for i in range(len(s)):
         ptr.store(i, ord(s[i]))
@@ -83,7 +75,7 @@ fn c_charptr_to_string(s: Pointer[c_char]) -> String:
     return String(s.bitcast[Int8](), strlen(s))
 
 
-#fn cftob(val: c_int) -> Bool:
+# fn cftob(val: c_int) -> Bool:
 #    """Convert C-like failure (-1) to Bool"""
 #    return rebind[Bool](val > 0)
 
@@ -101,7 +93,7 @@ fn external_call6[
 ](arg0: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) -> type:
     """Call an external function.
 
-    Parameters
+    Parameters:
       callee: The name of the external function.
       type: The return type.
       T0: The first argument type.
@@ -136,10 +128,10 @@ fn external_call6[
 
 
 # --- ( Network Related Constants )---------------------------------------------
-alias sa_family_t = c_ushort;
-alias socklen_t = c_uint;
-alias in_addr_t = c_uint;
-alias in_port_t = c_ushort;
+alias sa_family_t = c_ushort
+alias socklen_t = c_uint
+alias in_addr_t = c_uint
+alias in_port_t = c_ushort
 
 # Address Family Constants
 alias AF_UNSPEC = 0
@@ -347,16 +339,19 @@ alias SO_DETACH_REUSEPORT_BPF = 68
 struct in_addr:
     var s_addr: in_addr_t
 
+
 @value
 @register_passable("trivial")
 struct in6_addr:
-    var s6_addr: StaticArray[16, c_char]
+    var s6_addr: StaticTuple[16, c_char]
+
 
 @value
 @register_passable("trivial")
 struct sockaddr:
     var sa_family: sa_family_t
-    var sa_data: StaticArray[14, c_char]
+    var sa_data: StaticTuple[14, c_char]
+
 
 @value
 @register_passable("trivial")
@@ -364,7 +359,8 @@ struct sockaddr_in:
     var sin_family: sa_family_t
     var sin_port: in_port_t
     var sin_addr: in_addr
-    var sin_zero: StaticArray[8, c_char]
+    var sin_zero: StaticTuple[8, c_char]
+
 
 @value
 @register_passable("trivial")
@@ -374,6 +370,7 @@ struct sockaddr_in6:
     var sin6_flowinfo: c_uint
     var sin6_addr: in6_addr
     var sin6_scope_id: c_uint
+
 
 @value
 @register_passable("trivial")
@@ -387,145 +384,163 @@ struct addrinfo:
     var ai_canonname: Pointer[c_char]
     # FIXME(cristian): This should be Pointer[addrinfo]
     var ai_next: Pointer[c_void]
-    
+
     fn __init__() -> Self:
         return Self(
-            0,0,0,0,0,
-            Pointer[sockaddr](),
-            Pointer[c_char](),
-            Pointer[c_void]()
+            0, 0, 0, 0, 0, Pointer[sockaddr](), Pointer[c_char](), Pointer[c_void]()
         )
 
 
 fn strlen(s: Pointer[c_char]) -> c_size_t:
-    """libc POSIX `strlen` function
+    """Libc POSIX `strlen` function.
+
     Reference: https://man7.org/linux/man-pages/man3/strlen.3p.html
     Fn signature: size_t strlen(const char *s)
 
-    Args:
-    Returns:
-    """
+    Args: s: A pointer to a C string.
+    Returns: The length of the string."""
     return external_call["strlen", c_size_t, Pointer[c_char]](s)
 
 
 # --- ( Network Related Syscalls & Structs )------------------------------------
 
+
 fn htonl(hostlong: c_uint) -> c_uint:
-    """libc POSIX `htonl` function
+    """Libc POSIX `htonl` function.
+
     Reference: https://man7.org/linux/man-pages/man3/htonl.3p.html
     Fn signature: uint32_t htonl(uint32_t hostlong)
 
-    Args:
-    Returns:
-    """
+    Args: hostlong: A 32-bit unsigned integer in host byte order.
+    Returns: A 32-bit unsigned integer in network byte order."""
     return external_call["htonl", c_uint, c_uint](hostlong)
 
 
 fn htons(hostshort: c_ushort) -> c_ushort:
-    """libc POSIX `htons` function
+    """Libc POSIX `htons` function.
+
     Reference: https://man7.org/linux/man-pages/man3/htonl.3p.html
     Fn signature: uint16_t htons(uint16_t hostshort)
 
     Args:
-    Returns:
+        hostshort: A 16-bit unsigned integer in host byte order.
+    Returns: A 16-bit unsigned integer in network byte order.
     """
     return external_call["htons", c_ushort, c_ushort](hostshort)
 
 
 fn ntohl(netlong: c_uint) -> c_uint:
-    """libc POSIX `ntohl` function
+    """Libc POSIX `ntohl` function.
+
     Reference: https://man7.org/linux/man-pages/man3/htonl.3p.html
     Fn signature: uint32_t ntohl(uint32_t netlong)
 
     Args:
-    Returns:
+        netlong: A 32-bit unsigned integer in network byte order.
+    Returns: A 32-bit unsigned integer in host byte order.
     """
     return external_call["ntohl", c_uint, c_uint](netlong)
 
 
 fn ntohs(netshort: c_ushort) -> c_ushort:
-    """libc POSIX `ntohs` function
+    """Libc POSIX `ntohs` function.
+
     Reference: https://man7.org/linux/man-pages/man3/htonl.3p.html
     Fn signature: uint16_t ntohs(uint16_t netshort)
 
     Args:
-    Returns:
+        netshort: A 16-bit unsigned integer in network byte order.
+    Returns: A 16-bit unsigned integer in host byte order.
     """
     return external_call["ntohs", c_ushort, c_ushort](netshort)
 
 
 fn inet_ntop(
-    af: c_int, 
-    src: Pointer[c_void], 
-    dst: Pointer[c_char], 
-    size: socklen_t
+    af: c_int, src: Pointer[c_void], dst: Pointer[c_char], size: socklen_t
 ) -> Pointer[c_char]:
-    """libc POSIX `inet_ntop` function 
+    """Libc POSIX `inet_ntop` function.
+
     Reference: https://man7.org/linux/man-pages/man3/inet_ntop.3p.html.
     Fn signature: const char *inet_ntop(int af, const void *restrict src, char *restrict dst, socklen_t size)
 
     Args:
-        af: Address Family see AF_ alises
-        src:
-        dst: 
-        size:
+        af: Address Family see AF_ alises.
+        src: A pointer to a binary address.
+        dst: A pointer to a buffer to store the string representation of the address.
+        size: The size of the buffer pointed by dst.
 
-    Returns:
-        A pointer 
+    Returns: A pointer.
     """
     return external_call[
-        "inet_ntop", Pointer[c_char], # FnName, RetType
-        c_int, Pointer[c_void], Pointer[c_char], socklen_t # Args
+        "inet_ntop",
+        Pointer[c_char],  # FnName, RetType
+        c_int,
+        Pointer[c_void],
+        Pointer[c_char],
+        socklen_t,  # Args
     ](af, src, dst, size)
 
 
 fn inet_pton(af: c_int, src: Pointer[c_char], dst: Pointer[c_void]) -> c_int:
-    """libc POSIX `inet_pton` function
+    """Libc POSIX `inet_pton` function.
+
     Reference: https://man7.org/linux/man-pages/man3/inet_ntop.3p.html
     Fn signature: int inet_pton(int af, const char *restrict src, void *restrict dst)
 
     Args:
-    Returns:
+        af: Address Family see AF_ alises.
+        src: A pointer to a string representation of an address.
+        dst: A pointer to a buffer to store the binary address.
+    Returns: A pointer.
     """
     return external_call[
-        "inet_pton", c_int, # FnName, RetType
-        c_int, Pointer[c_char], Pointer[c_void] # Args
+        "inet_pton",
+        c_int,  # FnName, RetType
+        c_int,
+        Pointer[c_char],
+        Pointer[c_void],  # Args
     ](af, src, dst)
 
 
 fn inet_addr(cp: Pointer[c_char]) -> in_addr_t:
-    """libc POSIX `inet_addr` function
+    """Libc POSIX `inet_addr` function.
+
     Reference: https://man7.org/linux/man-pages/man3/inet_addr.3p.html
     Fn signature: in_addr_t inet_addr(const char *cp)
 
     Args:
-    Returns:
+        cp: A pointer to a string representation of an address.
+    Returns: A pointer.
     """
     return external_call["inet_addr", in_addr_t, Pointer[c_char]](cp)
 
 
 fn inet_ntoa(addr: in_addr) -> Pointer[c_char]:
-    """libc POSIX `inet_ntoa` function
+    """Libc POSIX `inet_ntoa` function.
+
     Reference: https://man7.org/linux/man-pages/man3/inet_addr.3p.html
     Fn signature: char *inet_ntoa(struct in_addr in)
 
-    Args:
-    Returns:
+    Args: in: A pointer to a binary address.
+    Returns: A pointer.
     """
     return external_call["inet_ntoa", Pointer[c_char], in_addr](addr)
-    
+
 
 fn socket(domain: c_int, type: c_int, protocol: c_int) -> c_int:
-    """libc POSIX `socket` function
+    """Libc POSIX `socket` function.
+
     Reference: https://man7.org/linux/man-pages/man3/socket.3p.html
     Fn signature: int socket(int domain, int type, int protocol)
 
     Args:
-    Returns:
+        domain: Address Family see AF_ alises.
+        type: Socket Type see SOCK_ alises.
+        protocol: Protocol see IPPROTO_ alises.
+    Returns: A pointer to a socket.
     """
     return external_call[
-        "socket", c_int, # FnName, RetType
-        c_int, c_int, c_int # Args
+        "socket", c_int, c_int, c_int, c_int  # FnName, RetType  # Args
     ](domain, type, protocol)
 
 
@@ -534,228 +549,278 @@ fn setsockopt(
     level: c_int,
     option_name: c_int,
     option_value: Pointer[c_void],
-    option_len: socklen_t
+    option_len: socklen_t,
 ) -> c_int:
-    """libc POSIX `setsockopt` function
+    """Libc POSIX `setsockopt` function.
+
     Reference: https://man7.org/linux/man-pages/man3/setsockopt.3p.html
     Fn signature: int setsockopt(int socket, int level, int option_name, const void *option_value, socklen_t option_len)
 
     Args:
-    Returns:
+        socket: A pointer to a socket.
+        level: Protocol Level see SOL_ alises.
+        option_name: Option name see SO_ alises.
+        option_value: A pointer to a buffer containing the option value.
+        option_len: The size of the buffer pointed by option_value.
+    Returns: A pointer to a socket opt.
     """
     return external_call[
-        "setsockopt", c_int, # FnName, RetType
-        c_int, c_int, c_int, Pointer[c_void], socklen_t # Args
+        "setsockopt",
+        c_int,  # FnName, RetType
+        c_int,
+        c_int,
+        c_int,
+        Pointer[c_void],
+        socklen_t,  # Args
     ](socket, level, option_name, option_value, option_len)
 
 
-fn bind(
-    socket: c_int,
-    address: Pointer[sockaddr],
-    address_len: socklen_t
-) -> c_int:
-    """libc POSIX `bind` function
+fn bind(socket: c_int, address: Pointer[sockaddr], address_len: socklen_t) -> c_int:
+    """Libc POSIX `bind` function.
+
     Reference: https://man7.org/linux/man-pages/man3/bind.3p.html
     Fn signature: int bind(int socket, const struct sockaddr *address, socklen_t address_len)
     """
     return external_call[
-        "bind", c_int, # FnName, RetType
-        c_int, Pointer[sockaddr], socklen_t # Args
+        "bind", c_int, c_int, Pointer[sockaddr], socklen_t  # FnName, RetType  # Args
     ](socket, address, address_len)
 
 
 fn listen(socket: c_int, backlog: c_int) -> c_int:
-    """libc POSIX `listen` function
+    """Libc POSIX `listen` function.
+
     Reference: https://man7.org/linux/man-pages/man3/listen.3p.html
     Fn signature: int listen(int socket, int backlog)
 
     Args:
-    Returns:
+        socket: A pointer to a socket.
+        backlog: The maximum length to which the queue of pending connections for socket may grow.
+    Returns: A pointer to a socket.
     """
     return external_call["listen", c_int, c_int, c_int](socket, backlog)
 
 
 fn accept(
-    socket: c_int,
-    address: Pointer[sockaddr],
-    address_len: Pointer[socklen_t]
+    socket: c_int, address: Pointer[sockaddr], address_len: Pointer[socklen_t]
 ) -> c_int:
-    """libc POSIX `accept` function
+    """Libc POSIX `accept` function.
+
     Reference: https://man7.org/linux/man-pages/man3/accept.3p.html
     Fn signature: int accept(int socket, struct sockaddr *restrict address, socklen_t *restrict address_len);
 
     Args:
-    Returns:
+        socket: A pointer to a socket.
+        address: A pointer to a buffer to store the address of the accepted socket.
+        address_len: A pointer to a buffer to store the length of the address of the accepted socket.
+    Returns: A pointer to a socket.
     """
     return external_call[
-        "accept", c_int, # FnName, RetType
-        c_int, Pointer[sockaddr], Pointer[socklen_t] # Args
+        "accept",
+        c_int,  # FnName, RetType
+        c_int,
+        Pointer[sockaddr],
+        Pointer[socklen_t],  # Args
     ](socket, address, address_len)
 
 
-fn connect(
-    socket: c_int,
-    address: Pointer[sockaddr],
-    address_len: socklen_t
-) -> c_int:
-    """libc POSIX `connect` function
+fn connect(socket: c_int, address: Pointer[sockaddr], address_len: socklen_t) -> c_int:
+    """Libc POSIX `connect` function.
+
     Reference: https://man7.org/linux/man-pages/man3/connect.3p.html
     Fn signature: int connect(int socket, const struct sockaddr *address, socklen_t address_len)
 
     Args:
-    Returns:
+        socket: A pointer to a socket.
+        address: A pointer to a buffer to store the address of the accepted socket.
+        address_len: A pointer to a buffer to store the length of the address of the accepted socket.
+    Returns: A pointer to a socket.
     """
     return external_call[
-        "connect", c_int, # FnName, RetType
-        c_int, Pointer[sockaddr], socklen_t # Args
+        "connect", c_int, c_int, Pointer[sockaddr], socklen_t  # FnName, RetType  # Args
     ](socket, address, address_len)
 
 
 fn recv(
-    socket: c_int,
-    buffer: Pointer[c_void],
-    length: c_size_t,
-    flags: c_int
+    socket: c_int, buffer: Pointer[c_void], length: c_size_t, flags: c_int
 ) -> c_ssize_t:
-    """libc POSIX `recv` function
+    """Libc POSIX `recv` function.
+
     Reference: https://man7.org/linux/man-pages/man3/recv.3p.html
     Fn signature: ssize_t recv(int socket, void *buffer, size_t length, int flags)
     """
     return external_call[
-        "recv", c_ssize_t, # FnName, RetType
-        c_int, Pointer[c_void], c_size_t, c_int # Args
+        "recv",
+        c_ssize_t,  # FnName, RetType
+        c_int,
+        Pointer[c_void],
+        c_size_t,
+        c_int,  # Args
     ](socket, buffer, length, flags)
 
 
 fn recvfrom(
-    socket: c_int, 
-    buffer: Pointer[c_void], 
-    length: c_size_t, 
-    flags: c_int, 
-    address: Pointer[sockaddr], 
-    address_len: Pointer[socklen_t]
+    socket: c_int,
+    buffer: Pointer[c_void],
+    length: c_size_t,
+    flags: c_int,
+    address: Pointer[sockaddr],
+    address_len: Pointer[socklen_t],
 ) -> c_ssize_t:
-    """libc POSIX `recvfrom` function
+    """Libc POSIX `recvfrom` function.
+
     Reference: https://man7.org/linux/man-pages/man3/recvfrom.3p.html
     Fn signature: ssize_t recvfrom(int socket, void *restrict buffer, size_t length, int flags, struct sockaddr *restrict address, socklen_t *restrict address_len)
     """
     return external_call6[
-        "recvfrom", c_ssize_t, # FnName, RetType
-        c_int, Pointer[c_void], c_size_t, c_int, Pointer[sockaddr], # Args 
-        Pointer[socklen_t] # Args
+        "recvfrom",
+        c_ssize_t,  # FnName, RetType
+        c_int,
+        Pointer[c_void],
+        c_size_t,
+        c_int,
+        Pointer[sockaddr],  # Args
+        Pointer[socklen_t],  # Args
     ](socket, buffer, length, flags, address, address_len)
-    
-    
+
+
 fn send(
-    socket: c_int,
-    buffer: Pointer[c_void],
-    length: c_size_t,
-    flags: c_int
+    socket: c_int, buffer: Pointer[c_void], length: c_size_t, flags: c_int
 ) -> c_ssize_t:
-    """libc POSIX `send` function
+    """Libc POSIX `send` function.
+
     Reference: https://man7.org/linux/man-pages/man3/send.3p.html
     Fn signature: ssize_t send(int socket, const void *buffer, size_t length, int flags)
 
     Args:
-    Returns:
+        socket: A pointer to a socket.
+        buffer: A pointer to a buffer to store the address of the accepted socket.
+        length: A pointer to a buffer to store the length of the address of the accepted socket.
+        flags: A pointer to a buffer to store the length of the address of the accepted socket.
+    Returns: A pointer to a socket.
     """
     return external_call[
-        "send", c_ssize_t, # FnName, RetType
-        c_int, Pointer[c_void], c_size_t, c_int # Args
+        "send",
+        c_ssize_t,  # FnName, RetType
+        c_int,
+        Pointer[c_void],
+        c_size_t,
+        c_int,  # Args
     ](socket, buffer, length, flags)
 
 
 fn sendto(
     socket: c_int,
-    message: Pointer[c_void], 
-    length: c_size_t, 
-    flags: c_int, 
-    dest_addr: Pointer[sockaddr], 
-    dest_len: socklen_t
+    message: Pointer[c_void],
+    length: c_size_t,
+    flags: c_int,
+    dest_addr: Pointer[sockaddr],
+    dest_len: socklen_t,
 ) -> c_ssize_t:
-    """libc POSIX `sendto` function
+    """Libc POSIX `sendto` function.
+
     Reference: https://man7.org/linux/man-pages/man3/sendto.3p.html
     Fn signature: ssize_t sendto(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len)
 
     Args:
-    Returns:
+        socket: A pointer to a socket.
+        message: A pointer to a buffer to store the address of the accepted socket.
+        length: A pointer to a buffer to store the length of the address of the accepted socket.
+        flags: A pointer to a buffer to store the length of the address of the accepted socket.
+        dest_addr: A pointer to a buffer to store the length of the address of the accepted socket.
+        dest_len: A pointer to a buffer to store the length of the address of the accepted socket.
+    Returns: A pointer to a socket.
     """
     return external_call6[
-        "sendto", c_ssize_t, # FnName, RetType
-        c_int, Pointer[c_void], c_size_t, c_int, Pointer[sockaddr], socklen_t # Args
+        "sendto",
+        c_ssize_t,  # FnName, RetType
+        c_int,
+        Pointer[c_void],
+        c_size_t,
+        c_int,
+        Pointer[sockaddr],
+        socklen_t,  # Args
     ](socket, message, length, flags, dest_addr, dest_len)
-    
+
 
 fn shutdown(socket: c_int, how: c_int) -> c_int:
-    """libc POSIX `shutdown` function
+    """Libc POSIX `shutdown` function.
+
     Reference: https://man7.org/linux/man-pages/man3/shutdown.3p.html
     Fn signature: int shutdown(int socket, int how)
 
     Args:
-    Returns:
+        socket: A pointer to a socket.
+        how: A pointer to a buffer to store the length of the address of the accepted socket.
+    Returns: A pointer to a socket.
     """
-    return external_call[
-        "shutdown", c_int, # FnName, RetType
-        c_int, c_int # Args
-    ](socket, how)
+    return external_call["shutdown", c_int, c_int, c_int](  # FnName, RetType  # Args
+        socket, how
+    )
 
 
 fn getaddrinfo(
     nodename: Pointer[c_char],
     servname: Pointer[c_char],
     hints: Pointer[addrinfo],
-    res: Pointer[Pointer[addrinfo]]
+    res: Pointer[Pointer[addrinfo]],
 ) -> c_int:
-    """libc POSIX `getaddrinfo` function
+    """Libc POSIX `getaddrinfo` function.
+
     Reference: https://man7.org/linux/man-pages/man3/getaddrinfo.3p.html
     Fn signature: int getaddrinfo(const char *restrict nodename, const char *restrict servname, const struct addrinfo *restrict hints, struct addrinfo **restrict res)
     """
     return external_call[
-        "getaddrinfo", c_int, # FnName, RetType
-        Pointer[c_char], Pointer[c_char], Pointer[addrinfo], # Args
-        Pointer[Pointer[addrinfo]] # Args
+        "getaddrinfo",
+        c_int,  # FnName, RetType
+        Pointer[c_char],
+        Pointer[c_char],
+        Pointer[addrinfo],  # Args
+        Pointer[Pointer[addrinfo]],  # Args
     ](nodename, servname, hints, res)
-    
+
 
 fn gai_strerror(ecode: c_int) -> Pointer[c_char]:
-    """libc POSIX `gai_strerror` function
+    """Libc POSIX `gai_strerror` function.
+
     Reference: https://man7.org/linux/man-pages/man3/gai_strerror.3p.html
     Fn signature: const char *gai_strerror(int ecode)
 
     Args:
-    Returns:
+        ecode: A pointer to a socket.
+    Returns: A pointer to a socket.
     """
     return external_call[
-        "gai_strerror", Pointer[c_char], # FnName, RetType
-        c_int # Args
+        "gai_strerror", Pointer[c_char], c_int  # FnName, RetType  # Args
     ](ecode)
 
 
-
-#fn get_addr(ptr: Pointer[sockaddr]) -> sockaddr:
+# fn get_addr(ptr: Pointer[sockaddr]) -> sockaddr:
 #    if ptr.load().sa_family == AF_INET:
 #        ptr.bitcast[sockaddr_in]().load().sin_addr
 #    return ptr.bitcast[sockaddr_in6]().load().sin6_addr
+
 
 fn inet_pton(address_family: Int, address: String) -> Int:
     var ip_buf_size = 4
     if address_family == AF_INET6:
         ip_buf_size = 16
-        
+
     let ip_buf = Pointer[c_void].alloc(ip_buf_size)
-    let conv_status = inet_pton(rebind[c_int](address_family), to_char_ptr(address), ip_buf)
+    let conv_status = inet_pton(
+        rebind[c_int](address_family), to_char_ptr(address), ip_buf
+    )
     return ip_buf.bitcast[c_uint]().load().to_int()
-    
+
 
 # --- ( File Related Syscalls & Structs )---------------------------------------
 alias off_t = Int64
 alias mode_t = UInt32
 
-alias FM_READ = 'r'
-alias FM_WRITE = 'w'
-alias FM_APPEND = 'a'
-alias FM_BINARY = 'b'
-alias FM_PLUS = '+'
+alias FM_READ = "r"
+alias FM_WRITE = "w"
+alias FM_APPEND = "a"
+alias FM_BINARY = "b"
+alias FM_PLUS = "+"
 
 alias SEEK_SET = 0
 alias SEEK_CUR = 1
@@ -776,7 +841,7 @@ alias O_CLOEXEC = 524288
 # from fcntl.h
 alias O_EXEC = -1
 alias O_SEARCH = -1
-alias O_DIRECTORY = -1 
+alias O_DIRECTORY = -1
 alias O_DSYNC = -1
 alias O_NOCTTY = -1
 alias O_NOFOLLOW = -1
@@ -818,604 +883,737 @@ alias AT_NO_AUTOMOUNT = 2048
 alias AT_EMPTY_PATH = 4096
 alias AT_RECURSIVE = 32768
 
+
 @register_passable("trivial")
 struct FILE:
     pass
 
 
 fn fcntl[*T: AnyType](fildes: c_int, cmd: c_int, *args: *T) -> c_int:
-    """libc POSIX `fcntl` function
+    """Libc POSIX `fcntl` function.
+
     Reference: https://man7.org/linux/man-pages/man3/close.3p.html
+
     Fn signature: int fcntl(int fildes, int cmd, ...)
-    
     Args:
-    Returns:
+        fildes: A File Descriptor to close.
+        cmd: A command to execute.
+        args: Arguments for the command, args: Arguments for the command.
+    Returns: Upon successful completion,0 shall be returned;
+    otherwise, -1 shall be returned and errno set to indicate the error.
     """
-    return external_call[
-        "fcntl", c_int, # FnName, RetType
-        c_int, c_int # Args
-    ](fildes, cmd, args)
+    return external_call["fcntl", c_int, c_int, c_int](  # FnName, RetType  # Args
+        fildes, cmd, args
+    )
 
 
 fn close(fildes: c_int) -> c_int:
-    """libc POSIX `close` function
+    """Libc POSIX `close` function.
+
     Reference: https://man7.org/linux/man-pages/man3/close.3p.html
     Fn signature: int close(int fildes)
 
     Args:
-        fildes: a File Descriptor to close
-
-    Returns:
-        Upon successful completion, 0 shall be returned; otherwise, -1
-        shall be returned and errno set to indicate the error.
+        fildes: A File Descriptor to close.
+    Returns: Upon successful completion, 0 shall be returned; otherwise, -1
+    shall be returned and errno set to indicate the error.
     """
     return external_call["close", c_int, c_int](fildes)
 
 
 fn open[*T: AnyType](path: Pointer[c_char], oflag: c_int, *args: *T) -> c_int:
-    """libc POSIX `open` function
+    """Libc POSIX `open` function.
+
     Reference: https://man7.org/linux/man-pages/man3/open.3p.html
     Fn signature: int open(const char *path, int oflag, ...)
 
     Args:
-        path:
-        oflag:
-        ...
-    Returns:
-        A File Descriptor or -1 in case of failure
+        path: A path to a file.
+        oflag: A flag to open the file with.
+        args: Arguments.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "open", c_int, # FnName, RetType
-        Pointer[c_char], c_int # Args
+        "open", c_int, Pointer[c_char], c_int  # FnName, RetType  # Args
     ](path, oflag, args)
 
 
-fn openat[*T: AnyType](
-    fd: c_int,
-    path: Pointer[c_char],
-    oflag: c_int,
-    *args: *T
-) -> c_int:
-    """libc POSIX `open` function
+fn openat[
+    *T: AnyType
+](fd: c_int, path: Pointer[c_char], oflag: c_int, *args: *T) -> c_int:
+    """Libc POSIX `open` function.
+
     Reference: https://man7.org/linux/man-pages/man3/open.3p.html
     Fn signature: int openat(int fd, const char *path, int oflag, ...)
 
     Args:
-        fd:
-        path:
-        oflag:
-        ...
-    Returns:
-        A File Descriptor or -1 in case of failure
+        fd: A File Descriptor to open the file with.
+        path: A path to a file.
+        oflag: A flag to open the file with.
+        args: Arguments.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "openat", c_int, # FnName, RetType
-        c_int, Pointer[c_char], c_int # Args
+        "openat", c_int, c_int, Pointer[c_char], c_int  # FnName, RetType  # Args
     ](fd, path, oflag, args)
 
 
 fn fopen(pathname: Pointer[c_char], mode: Pointer[c_char]) -> Pointer[FILE]:
-    """libc POSIX `fopen` function
+    """Libc POSIX `fopen` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fopen.3p.html
     Fn signature: FILE *fopen(const char *restrict pathname, const char *restrict mode)
 
     Args:
-    Returns:
+        pathname: A path to a file.
+        mode: A mode to open the file with.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "fopen", Pointer[FILE], # FnName, RetType
-        Pointer[c_char], Pointer[c_char] # Args
-    ](pathname, mode)  
+        "fopen",
+        Pointer[FILE],  # FnName, RetType
+        Pointer[c_char],
+        Pointer[c_char],  # Args
+    ](pathname, mode)
 
 
 fn fdopen(fildes: c_int, mode: Pointer[c_char]) -> Pointer[FILE]:
-    """libc POSIX `fdopen` function
+    """Libc POSIX `fdopen` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fdopen.3p.html
     Fn signature: FILE *fdopen(int fildes, const char *mode)
 
     Args:
-    Returns:
+        fildes: A File Descriptor to open the file with.
+        mode: A mode to open the file with.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "fdopen", Pointer[FILE], # FnName, RetType
-        c_int, Pointer[c_char] # Args
+        "fdopen", Pointer[FILE], c_int, Pointer[c_char]  # FnName, RetType  # Args
     ](fildes, mode)
 
 
 fn freopen(
-    pathname: Pointer[c_char], 
-    mode: Pointer[c_char],
-    stream: Pointer[FILE]
+    pathname: Pointer[c_char], mode: Pointer[c_char], stream: Pointer[FILE]
 ) -> Pointer[FILE]:
-    """libc POSIX `freopen` function
+    """Libc POSIX `freopen` function.
+
     Reference: https://man7.org/linux/man-pages/man3/freopen.3p.html
     Fn signature: FILE *freopen(const char *restrict pathname, const char *restrict mode, FILE *restrict stream)
 
     Args:
-    Returns:
+        pathname: A path to a file.
+        mode: A mode to open the file with.
+        stream: A pointer to a stream.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "freopen", Pointer[FILE], # FnName, RetType
-        Pointer[c_char], Pointer[c_char], Pointer[FILE] # Args
+        "freopen",
+        Pointer[FILE],  # FnName, RetType
+        Pointer[c_char],
+        Pointer[c_char],
+        Pointer[FILE],  # Args
     ](pathname, mode, stream)
 
 
 fn fmemopen(
-    buf: Pointer[c_void],
-    size: c_size_t,
-    mode: Pointer[c_char]
+    buf: Pointer[c_void], size: c_size_t, mode: Pointer[c_char]
 ) -> Pointer[FILE]:
-    """libc POSIX `fmemopen` function
+    """Libc POSIX `fmemopen` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fmemopen.3p.html
     Fn signature: FILE *fmemopen(void *restrict buf, size_t size, const char *restrict mode)
 
     Args:
-    Returns:
+        buf: A pointer to a buffer.
+        size: The size of the buffer.
+        mode: A mode to open the file with.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "fmemopen", Pointer[FILE], # FnName, RetType
-        Pointer[c_void], c_size_t, Pointer[c_char] # Args
+        "fmemopen",
+        Pointer[FILE],  # FnName, RetType
+        Pointer[c_void],
+        c_size_t,
+        Pointer[c_char],  # Args
     ](buf, size, mode)
 
 
 fn creat(path: Pointer[c_char], mode: mode_t) -> c_int:
-    """libc POSIX `creat` function
+    """Libc POSIX `creat` function.
+
     Reference: https://man7.org/linux/man-pages/man3/creat.3p.html
     Fn signature: int creat(const char *path, mode_t mode)
 
     Args:
-    Returns:
+        path: A path to a file.
+        mode: A mode to open the file with.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "creat", c_int, # FnName, RetType
-        Pointer[c_char], mode_t # Args
+        "creat", c_int, Pointer[c_char], mode_t  # FnName, RetType  # Args
     ](path, mode)
 
 
 fn fseek(stream: Pointer[FILE], offset: c_long, whence: c_int) -> c_int:
-    """libc POSIX `fseek` function
+    """Libc POSIX `fseek` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fseek.3p.html
     Fn signature: int fseek(FILE *stream, long offset, int whence)
 
     Args:
-    Returns:
+        stream: A pointer to a stream.
+        offset: An offset to seek to.
+        whence: A pointer to a buffer to store the length of the address of the accepted socket.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "fseek", c_int, # FnName, RetType
-        Pointer[FILE], c_long, c_int # Args
+        "fseek", c_int, Pointer[FILE], c_long, c_int  # FnName, RetType  # Args
     ](stream, offset, whence)
 
 
 fn fseeko(stream: Pointer[FILE], offset: off_t, whence: c_int) -> c_int:
-    """libc POSIX `fseeko` function
+    """Libc POSIX `fseeko` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fseek.3p.html
     Fn signature: int fseeko(FILE *stream, off_t offset, int whence)
-                    
+
     Args:
-    Returns:
+        stream: A pointer to a stream.
+        offset: An offset to seek to.
+        whence: A pointer to a buffer to store the length of the address of the accepted socket.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "fseeko", c_int, # FnName, RetType
-        Pointer[FILE], off_t, c_int # Args
+        "fseeko", c_int, Pointer[FILE], off_t, c_int  # FnName, RetType  # Args
     ](stream, offset, whence)
 
 
 fn lseek(fildes: c_int, offset: off_t, whence: c_int) -> off_t:
-    """libc POSIX `lseek` function
+    """Libc POSIX `lseek` function.
+
     Reference: https://man7.org/linux/man-pages/man3/lseek.3p.html
     Fn signature: off_t lseek(int fildes, off_t offset, int whence)
-                    
+
     Args:
-    Returns:
+        fildes: A File Descriptor to open the file with.
+        offset: An offset to seek to.
+        whence: A pointer to a buffer to store the length of the address of the accepted socket.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "lseek", off_t, # FnName, RetType
-        c_int, off_t, c_int # Args
+        "lseek", off_t, c_int, off_t, c_int  # FnName, RetType  # Args
     ](fildes, offset, whence)
 
 
 fn fputc(c: c_int, stream: Pointer[FILE]) -> c_int:
-    """libc POSIX `fputc` function
+    """Libc POSIX `fputc` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fputc.3p.html
     Fn signature: int fputc(int c, FILE *stream)
 
     Args:
-    Returns:
+        c: A character to write.
+        stream: A pointer to a stream.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "fputc", c_int, # FnName, RetType
-        c_int, Pointer[FILE] # Args
+        "fputc", c_int, c_int, Pointer[FILE]  # FnName, RetType  # Args
     ](c, stream)
 
+
 fn fputs(s: Pointer[c_char], stream: Pointer[FILE]) -> c_int:
-    """libc POSIX `fputs` function
+    """Libc POSIX `fputs` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fputs.3p.html
     Fn signature: int fputs(const char *restrict s, FILE *restrict stream)
 
     Args:
-    Returns:
+        s: A string to write.
+        stream: A pointer to a stream.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "fputs", c_int, # FnName, RetType
-        Pointer[c_char], Pointer[FILE] # Args
+        "fputs", c_int, Pointer[c_char], Pointer[FILE]  # FnName, RetType  # Args
     ](s, stream)
 
 
 fn fgetc(stream: Pointer[FILE]) -> c_int:
-    """libc POSIX `fgetc` function
+    """Libc POSIX `fgetc` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fgetc.3p.html
     Fn signature: int fgetc(FILE *stream)
 
     Args:
-    Returns:
+        stream: A pointer to a stream.
+    Returns: A File Descriptor or -1 in case of failure
     """
-    return external_call[
-        "fgets", c_int, # FnName, RetType
-        Pointer[FILE] # Args
-    ](stream)
+    return external_call["fgets", c_int, Pointer[FILE]](  # FnName, RetType  # Args
+        stream
+    )
 
 
 fn fgets(s: Pointer[c_char], n: c_int, stream: Pointer[FILE]) -> Pointer[c_char]:
-    """libc POSIX `fgets` function
+    """Libc POSIX `fgets` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fgets.3p.html
     Fn signature: char *fgets(char *restrict s, int n, FILE *restrict stream)
 
     Args:
-    Returns:
+        s: A pointer to a buffer to store the read string.
+        n: The maximum number of characters to read.
+        stream: A pointer to a stream.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "fgets", Pointer[c_char], # FnName, RetType
-        Pointer[c_char], c_int, Pointer[FILE] # Args
+        "fgets",
+        Pointer[c_char],  # FnName, RetType
+        Pointer[c_char],
+        c_int,
+        Pointer[FILE],  # Args
     ](s, n, stream)
 
 
-fn dprintf[*T: AnyType](
-    fildes: c_int,
-    format: Pointer[c_char],
-    *args: *T
-) -> c_int:
-    """libc POSIX `dprintf` function
+fn dprintf[*T: AnyType](fildes: c_int, format: Pointer[c_char], *args: *T) -> c_int:
+    """Libc POSIX `dprintf` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
     Fn signature: int dprintf(int fildes, const char *restrict format, ...)
 
     Args:
-    Returns:
+        fildes: A File Descriptor to open the file with.
+        format: A format string.
+        args: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "dprintf", c_int, # FnName, RetType
-        c_int, Pointer[c_char] # Args
+        "dprintf", c_int, c_int, Pointer[c_char]  # FnName, RetType  # Args
     ](fildes, format, args)
 
 
-fn fprintf[*T: AnyType](
-    stream: Pointer[FILE],
-    format: Pointer[c_char],
-    *args: *T
-) -> c_int:
-    """libc POSIX `fprintf` function
+fn fprintf[
+    *T: AnyType
+](stream: Pointer[FILE], format: Pointer[c_char], *args: *T) -> c_int:
+    """Libc POSIX `fprintf` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
     Fn signature: int fprintf(FILE *restrict stream, const char *restrict format, ...)
 
     Args:
+        stream: A pointer to a stream.
+        format: A format string.
+        args: Arguments for the format string.
     Returns:
     """
     return external_call[
-        "fprintf", c_int,  # FnName, RetType
-        Pointer[FILE], Pointer[c_char] # Args
+        "fprintf", c_int, Pointer[FILE], Pointer[c_char]  # FnName, RetType  # Args
     ](stream, format, args)
 
 
-fn printf[*T: AnyType](
-    format: Pointer[c_char],
-    *args: *T
-) -> c_int:
-    """libc POSIX `printf` function
+fn printf[*T: AnyType](format: Pointer[c_char], *args: *T) -> c_int:
+    """Libc POSIX `printf` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
     Fn signature: int printf(const char *restrict format, ...)
 
     Args:
-    Returns:
+        format: A format string.
+        args: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "printf", c_int, # FnName, RetType
-        Pointer[c_char], # Args
+        "printf",
+        c_int,  # FnName, RetType
+        Pointer[c_char],  # Args
     ](format, args)
 
 
-fn snprintf[*T: AnyType](
-    s: Pointer[c_char],
-    n: c_size_t,
-    format: Pointer[c_char],
-    *args: *T
-) -> c_int:
-    """libc POSIX `snprintf` function
+fn printf[*T: AnyType](format: Pointer[c_char]) -> c_int:
+    """Libc POSIX `printf` function.
+
+    Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
+    Fn signature: int printf(const char *restrict format, ...)
+
+    Args:
+        format: A format string.
+    Returns: A File Descriptor or -1 in case of failure
+    """
+    return external_call[
+        "printf",
+        c_int,  # FnName, RetType
+        Pointer[c_char],  # Args
+    ](format)
+
+
+fn printf[*T: AnyType](format: StringLiteral, *args: *T) -> c_int:
+    """Libc POSIX `printf` function.
+
+    Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
+    Fn signature: int printf(const char *restrict format, ...)
+
+    Args:
+        format: A format string.
+        args: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
+    """
+    return external_call[
+        "printf",
+        c_int,  # FnName, RetType
+        Pointer[c_char],  # Args
+    ](to_char_ptr(format), args)
+
+
+fn printf[*T: AnyType](format: StringLiteral) -> c_int:
+    """Libc POSIX `printf` function.
+
+    Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
+    Fn signature: int printf(const char *restrict format, ...)
+
+    Args:
+        format: A format string.
+    Returns: A File Descriptor or -1 in case of failure
+    """
+    return external_call[
+        "printf",
+        c_int,  # FnName, RetType
+        Pointer[c_char],  # Args
+    ](to_char_ptr(format))
+
+
+fn snprintf[
+    *T: AnyType
+](s: Pointer[c_char], n: c_size_t, format: Pointer[c_char], *args: *T) -> c_int:
+    """Libc POSIX `snprintf` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
     Fn signature: int snprintf(char *restrict s, size_t n, const char *restrict format, ...)
 
     Args:
-    Returns:
+        s: A pointer to a buffer to store the read string.
+        n: The maximum number of characters to read.
+        format: A format string.
+        args: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "snprintf", c_int, # FnName, RetType
-        Pointer[c_char], c_size_t, Pointer[c_char] # Args
+        "snprintf",
+        c_int,  # FnName, RetType
+        Pointer[c_char],
+        c_size_t,
+        Pointer[c_char],  # Args
     ](s, n, format, args)
 
 
-fn sprintf[*T: AnyType](
-    s: Pointer[c_char],
-    format: Pointer[c_char],
-    *args: *T
-) -> c_int:
-    """libc POSIX `sprintf` function
+fn sprintf[
+    *T: AnyType
+](s: Pointer[c_char], format: Pointer[c_char], *args: *T) -> c_int:
+    """Libc POSIX `sprintf` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fprintf.3p.html
     Fn signature: int sprintf(char *restrict s, const char *restrict format, ...)
 
     Args:
-    Returns:
+        s: A pointer to a buffer to store the read string.
+        format: A format string.
+        args: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "sprintf", c_int, # FnName, RetType
-        Pointer[c_char], Pointer[c_char] # Args
+        "sprintf", c_int, Pointer[c_char], Pointer[c_char]  # FnName, RetType  # Args
     ](s, format, args)
 
 
-fn fscanf[*T: AnyType](
-    stream: Pointer[FILE],
-    format: Pointer[c_char],
-    *args: *T
-) -> c_int:
-    """libc POSIX `fscanf` function
+fn fscanf[
+    *T: AnyType
+](stream: Pointer[FILE], format: Pointer[c_char], *args: *T) -> c_int:
+    """Libc POSIX `fscanf` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fscanf.3p.html
     Fn signature: int fscanf(FILE *restrict stream, const char *restrict format, ...)
 
     Args:
-    Returns:
+        stream: A pointer to a stream.
+        format: A format string.
+        args: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "fscanf", c_int, # FnName, RetType
-        Pointer[FILE], Pointer[c_char] # Args
+        "fscanf", c_int, Pointer[FILE], Pointer[c_char]  # FnName, RetType  # Args
     ](stream, format, args)
 
 
 fn scanf[*T: AnyType](format: Pointer[c_char], *args: *T) -> c_int:
-    """libc POSIX `scanf` function
+    """Libc POSIX `scanf` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fscanf.3p.html
     Fn signature: int scanf(const char *restrict format, ...)
 
     Args:
-    Returns:
+        format: A format string.
+        args: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
     """
-    return external_call[
-        "scanf", c_int, # FnName, RetType
-        Pointer[c_char] # Args
-    ](format, args)
+    return external_call["scanf", c_int, Pointer[c_char]](  # FnName, RetType  # Args
+        format, args
+    )
 
 
-fn sscanf[*T: AnyType](
-    s: Pointer[c_char],
-    format: Pointer[c_char],
-    *args: *T
-) -> c_int:
-    """libc POSIX `sscanf` function
+fn sscanf[*T: AnyType](s: Pointer[c_char], format: Pointer[c_char], *args: *T) -> c_int:
+    """Libc POSIX `sscanf` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fscanf.3p.html
     Fn signature: int sscanf(const char *restrict s, const char *restrict format, ...)
 
     Args:
-    Returns:
+        s: A pointer to a buffer to store the read string.
+        format: A format string.
+        args: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "sscanf", c_int, # FnName, RetType
-        Pointer[c_char], Pointer[c_char] # Args
+        "sscanf", c_int, Pointer[c_char], Pointer[c_char]  # FnName, RetType  # Args
     ](s, format, args)
-    
+
 
 fn fread(
-    ptr: Pointer[c_void],
-    size: c_size_t,
-    nitems: c_size_t,
-    stream: Pointer[FILE]
+    ptr: Pointer[c_void], size: c_size_t, nitems: c_size_t, stream: Pointer[FILE]
 ) -> c_int:
-    """libc POSIX `fread` function
+    """Libc POSIX `fread` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fread.3p.html
     Fn signature: size_t fread(void *restrict ptr, size_t size, size_t nitems, FILE *restrict stream)
 
     Args:
-    Returns:
+        ptr: A pointer to a buffer to store the read string.
+        size: The size of the buffer.
+        nitems: The number of items to read.
+        stream: A pointer to a stream.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "fread", c_size_t, # FnName, RetType
-        Pointer[c_void], c_size_t, c_size_t, Pointer[FILE] # Args
+        "fread",
+        c_size_t,  # FnName, RetType
+        Pointer[c_void],
+        c_size_t,
+        c_size_t,
+        Pointer[FILE],  # Args
     ](ptr, size, nitems, stream)
 
 
 fn rewind(stream: Pointer[FILE]) -> c_void:
-    """libc POSIX `rewind` function
+    """Libc POSIX `rewind` function.
+
     Reference: https://man7.org/linux/man-pages/man3/rewind.3p.html
     Fn signature: void rewind(FILE *stream)
 
     Args:
-    Returns:
+        stream: A pointer to a stream.
+    Returns: void
     """
     return external_call["rewind", c_void, Pointer[FILE]](stream)
 
 
 fn getline(
-    lineptr: Pointer[Pointer[FILE]],
-    n: Pointer[c_size_t],
-    stream: Pointer[FILE]
+    lineptr: Pointer[Pointer[FILE]], n: Pointer[c_size_t], stream: Pointer[FILE]
 ) -> c_ssize_t:
-    """libc POSIX `getline` function
+    """Libc POSIX `getline` function.
+
     Reference: https://man7.org/linux/man-pages/man3/getline.3p.html
     Fn signature: ssize_t getline(char **restrict lineptr, size_t *restrict n, FILE *restrict stream);
 
-
     Args:
-    Returns:
+        lineptr: A pointer to a pointer to a buffer to store the read string.
+        n: A pointer to a buffer to store the length of the address of the accepted socket.
+        stream: A pointer to a stream.
+    Returns: Size of the lines read.
     """
     return external_call[
-        "getline", c_ssize_t,  # FnName, RetType
-        Pointer[Pointer[FILE]], Pointer[c_size_t], Pointer[FILE] # Args
+        "getline",
+        c_ssize_t,  # FnName, RetType
+        Pointer[Pointer[FILE]],
+        Pointer[c_size_t],
+        Pointer[FILE],  # Args
     ](lineptr, n, stream)
 
 
-fn pread(
-    fildes: c_int, 
-    buf: Pointer[c_void], 
-    nbyte: c_size_t, 
-    offset: off_t
-) -> c_int:
-    """libc POSIX `pread` function
+fn pread(fildes: c_int, buf: Pointer[c_void], nbyte: c_size_t, offset: off_t) -> c_int:
+    """Libc POSIX `pread` function.
+
     Reference: https://man7.org/linux/man-pages/man3/read.3p.html
     Fn signature: ssize_t pread(int fildes, void *buf, size_t nbyte, off_t offset)
 
     Args:
-    Returns:
+        fildes: A File Descriptor to open the file with.
+        buf: A pointer to a buffer to store the read string.
+        nbyte: The maximum number of characters to read.
+        offset: An offset to seek to.
+    Returns: A File Descriptor or -1 in case of failure
     """
-    return external_call[
-        "pread", c_ssize_t, 
-        c_int, Pointer[c_void], c_size_t, off_t
-    ](fildes, buf, nbyte, offset)
+    return external_call["pread", c_ssize_t, c_int, Pointer[c_void], c_size_t, off_t](
+        fildes, buf, nbyte, offset
+    )
 
 
 fn read(fildes: c_int, buf: Pointer[c_void], nbyte: c_size_t) -> c_int:
-    """libc POSIX `read` function
+    """Libc POSIX `read` function.
+
     Reference: https://man7.org/linux/man-pages/man3/read.3p.html
     Fn signature: sssize_t read(int fildes, void *buf, size_t nbyte)
 
     Args:
-    Returns:
+        fildes: A File Descriptor to open the file with.
+        buf: A pointer to a buffer to store the read string.
+        nbyte: The maximum number of characters to read.
+    Returns: Amount of bytes read.
     """
-    return external_call[
-        "read", c_ssize_t, 
-        c_int, Pointer[c_void], c_size_t
-    ](fildes, buf, nbyte)
+    return external_call["read", c_ssize_t, c_int, Pointer[c_void], c_size_t](
+        fildes, buf, nbyte
+    )
 
 
-fn pwrite(
-    fildes: c_int,
-    buf: Pointer[c_void],
-    nbyte: c_size_t,
-    offset: off_t
-) -> c_int:
-    """libc POSIX `pwrite` function
+fn pwrite(fildes: c_int, buf: Pointer[c_void], nbyte: c_size_t, offset: off_t) -> c_int:
+    """Libc POSIX `pwrite` function.
+
     Reference: https://man7.org/linux/man-pages/man3/write.3p.html
     Fn signature: ssize_t pwrite(int fildes, const void *buf, size_t nbyte, off_t offset)
 
     Args:
-    Returns:
+        fildes: A File Descriptor to open the file with.
+        buf: A pointer to a buffer to store the read string.
+        nbyte: The maximum number of characters to read.
+        offset: An offset to seek to.
+    Returns: Amount of bytes written.
     """
-    return external_call[
-        "pwrite", c_ssize_t, 
-        c_int, Pointer[c_void], c_size_t, off_t
-    ](fildes, buf, nbyte, offset)
+    return external_call["pwrite", c_ssize_t, c_int, Pointer[c_void], c_size_t, off_t](
+        fildes, buf, nbyte, offset
+    )
 
 
 fn write(fildes: c_int, buf: Pointer[c_void], nbyte: c_size_t) -> c_int:
-    """libc POSIX `write` function
+    """Libc POSIX `write` function.
+
     Reference: https://man7.org/linux/man-pages/man3/write.3p.html
     Fn signature: ssize_t write(int fildes, const void *buf, size_t nbyte);
 
     Args:
-    Returns:
+        fildes: A File Descriptor to open the file with.
+        buf: A pointer to a buffer to store the read string.
+        nbyte: The maximum number of characters to read.
+    Returns: Amount of bytes written.
     """
-    return external_call[
-        "write", c_ssize_t, 
-        c_int, Pointer[c_void], c_size_t
-    ](fildes, buf, nbyte)
+    return external_call["write", c_ssize_t, c_int, Pointer[c_void], c_size_t](
+        fildes, buf, nbyte
+    )
 
 
 fn fclose(stream: Pointer[FILE]) -> c_int:
-    """libc POSIX `fclose` function
+    """Libc POSIX `fclose` function.
+
     Reference: https://man7.org/linux/man-pages/man3/fclose.3p.html
     Fn signature: int fclose(FILE *stream)
 
     Args:
-        stream:
-    Returns:
+        stream: A pointer to a stream.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call["fclose", c_int, Pointer[FILE]](stream)
 
+
 fn ftell(stream: Pointer[FILE]) -> c_long:
-    """libc POSIX `ftell` function
+    """Libc POSIX `ftell` function.
+
     Reference: https://man7.org/linux/man-pages/man3/ftell.3p.html
     Fn signature: long ftell(FILE *stream)
 
     Args:
-    Returns:
+        stream: A pointer to a stream.
+    Returns: The current file position of the given stream.
     """
     return external_call["ftell", c_long, Pointer[FILE]](stream)
 
 
 fn ftello(stream: Pointer[FILE]) -> off_t:
-    """libc POSIX `ftello` function
+    """Libc POSIX `ftello` function.
+
     Reference: https://man7.org/linux/man-pages/man3/ftell.3p.html
     Fn signature: off_t ftello(FILE *stream)
 
     Args:
-    Returns:
+        stream: A pointer to a stream.
+    Returns: The current file position of the given stream.
     """
     return external_call["ftello", off_t, Pointer[FILE]](stream)
-    
 
-fn fflush(stream: Pointer[FILE]) -> c_int:
-    """libc POSIX `fflush` function
-    Reference: https://man7.org/linux/man-pages/man3/fflush.3p.html
-    Fn signature: int fflush(FILE *stream)
 
-    Args:
-        stream
+# fn fflush(stream: Pointer[FILE]) -> c_int:
+#     """Libc POSIX `fflush` function.
+#     Reference: https://man7.org/linux/man-pages/man3/fflush.3p.html
+#     Fn signature: int fflush(FILE *stream)
+#
+#     Args:
+#         stream
+#
+#     Returns:
+#     """
+#     return external_call["fflush", c_int, Pointer[FILE]](stream)
+#
 
-    Returns:
-    """
-    return external_call["fflush", c_int, Pointer[FILE]](stream)
-  
 
 fn clearerr(stream: Pointer[FILE]) -> c_void:
-    """libc POSIX `feof` function
+    """Libc POSIX `feof` function.
+
     Reference: https://man7.org/linux/man-pages/man3/clearerr.3p.html
     Fn signature: void clearerr(FILE *stream)
 
     Args:
-    Returns:
+        stream: A pointer to a stream.
+    Returns: void
     """
     return external_call["clearerr", c_void, Pointer[FILE]](stream)
 
 
 fn feof(stream: Pointer[FILE]) -> c_int:
-    """libc POSIX `feof` function
+    """Libc POSIX `feof` function.
+
     Reference: https://man7.org/linux/man-pages/man3/feof.3p.html
     Fn signature: int feof(FILE *stream)
 
     Args:
-    Returns:
+        stream: A pointer to a stream.
+    Returns: 1 if the end-of-file indicator associated with the stream is set, else 0.
     """
     return external_call["feof", c_int, Pointer[FILE]](stream)
 
 
 fn ferror(stream: Pointer[FILE]) -> c_int:
-    """libc POSIX `ferror` function
+    """Libc POSIX `ferror` function.
+
     Reference: https://man7.org/linux/man-pages/man3/ferror.3p.html
     Fn signature: int ferror(FILE *stream)
 
     Args:
-    Returns:
+        stream: A pointer to a stream.
+    Returns: 1 if the error indicator associated with the stream is set, else 0.
     """
     return external_call["ferror", c_int, Pointer[FILE]](stream)
 
 
 fn ioctl[*T: AnyType](fildes: c_int, request: c_int, *args: *T) -> c_int:
-    """libc POSIX `ioctl` function
+    """Libc POSIX `ioctl` function.
+
     Reference: https://man7.org/linux/man-pages/man3/ioctl.3p.html
     Fn signature: int ioctl(int fildes, int request, ... /* arg */)
 
     TODO(cristian): add ioctl Options
     Args:
-    Returns:
+        fildes: A File Descriptor to open the file with.
+        request: An offset to seek to.
+        args: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
     """
-    return external_call[
-        "ioctl", c_int, # FnName, RetType
-        c_int, c_int # Args
-    ](fildes, request, args)
+    return external_call["ioctl", c_int, c_int, c_int](  # FnName, RetType  # Args
+        fildes, request, args
+    )
 
 
 # --- ( Logging Syscalls ) -----------------------------------------------------
@@ -1441,7 +1639,7 @@ alias LOG_LOCAL4 = -1
 alias LOG_LOCAL5 = -1
 alias LOG_LOCAL6 = -1
 alias LOG_LOCAL7 = -1
-alias LOG_MASK = -1 # (pri)
+alias LOG_MASK = -1  # (pri)
 alias LOG_EMERG = -1
 alias LOG_ALERT = -1
 alias LOG_CRIT = -1
@@ -1451,171 +1649,194 @@ alias LOG_NOTICE = -1
 alias LOG_INFO = -1
 alias LOG_DEBUG = -1
 
+
 fn openlog(ident: Pointer[c_char], logopt: c_int, facility: c_int) -> c_void:
-    """libc POSIX `openlog` function
+    """Libc POSIX `openlog` function.
+
     Reference: https://man7.org/linux/man-pages/man3/closelog.3p.html
     Fn signature: void openlog(const char *ident, int logopt, int facility)
 
     Args:
-    Returns:
+        ident: A File Descriptor to open the file with.
+        logopt: An offset to seek to.
+        facility: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "openlog", c_void, # FnName, RetType
-        Pointer[c_char], c_int, c_int # Args
+        "openlog", c_void, Pointer[c_char], c_int, c_int  # FnName, RetType  # Args
     ](ident, logopt, facility)
-    
 
-fn syslog[*T: AnyType](
-    priority: c_int,
-    message: Pointer[c_char],
-    *args: *T
-) -> c_void:
-    """libc POSIX `syslog` function
+
+fn syslog[*T: AnyType](priority: c_int, message: Pointer[c_char], *args: *T) -> c_void:
+    """Libc POSIX `syslog` function.
+
     Reference: https://man7.org/linux/man-pages/man3/closelog.3p.html
     Fn signature: void syslog(int priority, const char *message, ... /* arguments */)
 
     Args:
-    Returns:
+        priority: A File Descriptor to open the file with.
+        message: An offset to seek to.
+        args: Arguments for the format string.
+    Returns: A File Descriptor or -1 in case of failure
     """
     return external_call[
-        "syslog", c_void, # FnName, RetType
-        c_int, Pointer[c_char] # Args
+        "syslog", c_void, c_int, Pointer[c_char]  # FnName, RetType  # Args
     ](priority, message, args)
 
-    
+
 fn setlogmask(maskpri: c_int) -> c_int:
-    """libc POSIX `setlogmask` function
+    """Libc POSIX `setlogmask` function.
+
     Reference: https://man7.org/linux/man-pages/man3/closelog.3p.html
     Fn signature:  int setlogmask(int maskpri)
 
     Args:
-    Returns:
+        maskpri: A File Descriptor to open the file with.
+    Returns: A File Descriptor or -1 in case of failure
     """
-    return external_call[
-        "setlogmask", c_int, # FnName, RetType
-        c_int # Args
-    ](maskpri)
+    return external_call["setlogmask", c_int, c_int](maskpri)  # FnName, RetType  # Args
 
-    
+
 fn closelog():
-    """libc POSIX `closelog` function
+    """Libc POSIX `closelog` function.
+
     Reference: https://man7.org/linux/man-pages/man3/closelog.3p.html
     Fn signature: void closelog(void)
-
-    Args:
-    Returns:
     """
     _ = external_call["closelog", c_void]()
 
 
 # --- ( Testing Functions ) ----------------------------------------------------
 
+
 fn __test_getaddrinfo__():
     let ip_addr = "127.0.0.1"
     let port = 8083
-    
+
     var servinfo = Pointer[addrinfo]().alloc(1)
     servinfo.store(addrinfo())
-    
+
     var hints = addrinfo()
     hints.ai_family = AF_INET
     hints.ai_socktype = SOCK_STREAM
     hints.ai_flags = AI_PASSIVE
-    #let hints_ptr = 
+    # let hints_ptr =
 
-    let status = getaddrinfo(to_char_ptr(ip_addr), Pointer[UInt8](), Pointer.address_of(hints), Pointer.address_of(servinfo))
+    let status = getaddrinfo(
+        to_char_ptr(ip_addr),
+        Pointer[UInt8](),
+        Pointer.address_of(hints),
+        Pointer.address_of(servinfo),
+    )
     let msg_ptr = gai_strerror(c_int(status))
-    _ = external_call["printf", c_int, Pointer[c_char],  Pointer[c_char]](to_char_ptr("gai_strerror: %s"), msg_ptr)
+    _ = external_call["printf", c_int, Pointer[c_char], Pointer[c_char]](
+        to_char_ptr("gai_strerror: %s"), msg_ptr
+    )
     let msg = c_charptr_to_string(msg_ptr)
-    _printf("getaddrinfo satus: %d", msg)     
-    #getaddrinfo()
+    _ = printf("getaddrinfo satus: %d", msg)
+    # getaddrinfo()
 
 
 fn __test_socket_client__():
-    let ip_addr = "127.0.0.1" # The server's hostname or IP address
-    let port = 8083 # The port used by the server
+    let ip_addr = "127.0.0.1"  # The server's hostname or IP address
+    let port = 8083  # The port used by the server
     let address_family = AF_INET
-    
+
     let ip_buf = Pointer[c_void].alloc(4)
     let conv_status = inet_pton(address_family, to_char_ptr(ip_addr), ip_buf)
     let raw_ip = ip_buf.bitcast[c_uint]().load()
-    
-    _printf("inet_pton: %d :: status: %d\n", raw_ip, conv_status) 
-    
-    let bin_port = htons(UInt16(port))
-    _printf("htons: %d\n", bin_port) 
 
-    var ai = sockaddr_in(address_family, bin_port, raw_ip, StaticArray[8, c_char]())
+    _ = printf("inet_pton: %d :: status: %d\n", raw_ip, conv_status)
+
+    let bin_port = htons(UInt16(port))
+    _ = printf("htons: %d\n", bin_port)
+
+    var ai = sockaddr_in(address_family, bin_port, raw_ip, StaticTuple[8, c_char]())
     let ai_ptr = Pointer[sockaddr_in].address_of(ai).bitcast[sockaddr]()
-    
+
     let sockfd = socket(address_family, SOCK_STREAM, 0)
     if sockfd == -1:
         print("Socket creation error")
-    _printf("sockfd: %d\n", sockfd)
-    
+    _ = printf("sockfd: %d\n", sockfd)
+
     if connect(sockfd, ai_ptr, sizeof[sockaddr_in]()) == -1:
         _ = shutdown(sockfd, SHUT_RDWR)
-    
+
     let msg = to_char_ptr("Hello, world Server")
     let bytes_sent = send(sockfd, msg, strlen(msg), 0)
     if bytes_sent == -1:
         _ = shutdown(sockfd, SHUT_RDWR)
-        _printf("failed to send message\n")
-        
+        _ = printf("failed to send message\n")
+
     let buf_size = 1024
     var buf = Pointer[UInt8]().alloc(buf_size)
     let bytes_recv = recv(sockfd, buf, buf_size, 0)
     if bytes_recv == -1:
         _ = shutdown(sockfd, SHUT_RDWR)
-        _printf("failed to receive message\n")
+        _ = printf("failed to receive message\n")
     print("Recived Message: ")
     print(String(buf.bitcast[Int8](), bytes_recv))
 
-    
+
 fn __test_socket_server__() raises:
     let ip_addr = "127.0.0.1"
     let port = 8083
-    
+
     let address_family = AF_INET
     var ip_buf_size = 4
     if address_family == AF_INET6:
         ip_buf_size = 16
-    
+
     let ip_buf = Pointer[c_void].alloc(ip_buf_size)
     let conv_status = inet_pton(address_family, to_char_ptr(ip_addr), ip_buf)
     let raw_ip = ip_buf.bitcast[c_uint]().load()
-    
-    _printf("inet_pton: %d :: status: %d\n", raw_ip, conv_status) 
-    
-    let bin_port = htons(UInt16(port))
-    _printf("htons: %d\n", bin_port) 
 
-    var ai = sockaddr_in(address_family, bin_port, raw_ip, StaticArray[8, c_char]())
+    _ = printf("inet_pton: %d :: status: %d\n", raw_ip, conv_status)
+
+    let bin_port = htons(UInt16(port))
+    _ = printf("htons: %d\n", bin_port)
+
+    var ai = sockaddr_in(address_family, bin_port, raw_ip, StaticTuple[8, c_char]())
     let ai_ptr = Pointer[sockaddr_in].address_of(ai).bitcast[sockaddr]()
-    
+
     let sockfd = socket(address_family, SOCK_STREAM, 0)
     if sockfd == -1:
         print("Socket creation error")
-    _printf("sockfd: %d\n", sockfd)
-    
+    _ = printf("sockfd: %d\n", sockfd)
+
     var yes: Int = 1
-    if setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, Pointer[Int].address_of(yes).bitcast[c_void](), sizeof[Int]()) == -1:
+    if (
+        setsockopt(
+            sockfd,
+            SOL_SOCKET,
+            SO_REUSEADDR,
+            Pointer[Int].address_of(yes).bitcast[c_void](),
+            sizeof[Int](),
+        )
+        == -1
+    ):
         print("set socket options failed")
 
     if bind(sockfd, ai_ptr, sizeof[sockaddr_in]()) == -1:
         # close(sockfd)
         _ = shutdown(sockfd, SHUT_RDWR)
         print("Binding socket failed")
-    
+
     if listen(sockfd, c_int(128)) == -1:
-        _printf("Listen %d failed.\n", sockfd)
-    
-    
-    _printf("server: started at %s : %d with fd %d – waiting for connections...\n", ip_addr, port, sockfd)
+        _ = printf("Listen %d failed.\n", sockfd)
+
+    _ = printf(
+        "server: started at %s : %d with fd %d – waiting for connections...\n",
+        ip_addr,
+        port,
+        sockfd,
+    )
 
     let their_addr_ptr = Pointer[sockaddr].alloc(1)
     var sin_size = socklen_t(sizeof[socklen_t]())
-    let new_sockfd = accept(sockfd, their_addr_ptr, Pointer[socklen_t].address_of(sin_size))
+    let new_sockfd = accept(
+        sockfd, their_addr_ptr, Pointer[socklen_t].address_of(sin_size)
+    )
     if new_sockfd == -1:
         print("Accept failed")
         # close(sockfd)
@@ -1623,15 +1844,15 @@ fn __test_socket_server__() raises:
 
     # inet_ntop(their_addr.ss_family, get_in_addr((struct sockaddr *)&their_addr), s, sizeof s);
     # printf("server: got connection from %s\n", s);
-    
+
     let msg = "Hello, Mojo!"
     if send(new_sockfd, to_char_ptr(msg).bitcast[c_void](), len(msg), 0) == -1:
         print("Failed to send response")
     print("Message sent succesfully")
-        # close(new_fd)
+    # close(new_fd)
     _ = shutdown(sockfd, SHUT_RDWR)
     # close(new_fd)
-        
+
 
 fn __test_file__():
     let fp = fopen(to_char_ptr("test.mojo"), to_char_ptr("r"))
@@ -1645,7 +1866,13 @@ fn __test_file__():
     _ = fclose(fp)
 
 
-# __test_getaddrinfo__()
-# __test_socket_client__()
-# __test_socket_server__()
-# __test_file__()
+fn main():
+    __test_getaddrinfo__()
+    __test_socket_client__()
+
+    try:
+        __test_socket_server__()
+    except e:
+        print(e.value)
+
+    __test_file__()


### PR DESCRIPTION
- Fix error in `printf`
- Add more implementations of `printf`
- Fix all warnings so we can use the tooling (I think `lsp` crashes after certain amount of warnings)
- Rename to `libc.mojo` since that's what the `mojo` team did